### PR TITLE
Update order status

### DIFF
--- a/src/helpers/baseHelper.js
+++ b/src/helpers/baseHelper.js
@@ -1,15 +1,5 @@
 import bcrypt from 'bcryptjs';
-import { validationResult } from 'express-validator';
 
-export const handleErrors = (req, res, next) => {
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) {
-    return res.status(400).json({
-      error: errors.array().map((i) => i.msg),
-    });
-  }
-  return next();
-};
 export const hashPassword = (password) => {
   const salt = bcrypt.genSaltSync(10);
   const hash = bcrypt.hashSync(password, salt);

--- a/src/middlewares/baseMiddleware.js
+++ b/src/middlewares/baseMiddleware.js
@@ -1,0 +1,13 @@
+import { validationResult } from 'express-validator';
+
+const handleErrors = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({
+      error: errors.array().map((i) => i.msg),
+    });
+  }
+  return next();
+};
+
+export default handleErrors;

--- a/src/middlewares/validateCategory.js
+++ b/src/middlewares/validateCategory.js
@@ -1,6 +1,7 @@
 import { body, check } from 'express-validator';
 import { getCategoryByAttribute } from '../resources/category/models/index.model';
-import { formatResponse, handleErrors} from '../helpers/baseHelper';
+import { formatResponse } from '../helpers/baseHelper';
+import handleErrors from './baseMiddleware';
 
 export const validateCategory = [
   check('name')

--- a/src/middlewares/validateOrder.js
+++ b/src/middlewares/validateOrder.js
@@ -1,7 +1,10 @@
 import { check } from 'express-validator';
-import { handleErrors } from '../helpers/baseHelper';
+import handleErrors from './baseMiddleware';
+import { STATUSES } from '../resources/order/models/order.model';
+import { formatResponse } from '../helpers/baseHelper';
+import { getOrderByAttribute } from '../resources/order/models/index.model';
 
-const validateOrder = [
+export const validateOrder = [
   check('shipping_address')
     .isLength({ min: 1 })
     .withMessage('Please input the shipping address')
@@ -29,4 +32,55 @@ const validateOrder = [
   (req, res, next) => handleErrors(req, res, next),
 ];
 
-export default validateOrder;
+export const checkStatus = (req, res, next) => {
+  const { status } = req.body;
+
+  if (STATUSES.includes(status)) {
+    return formatResponse(res, { error: 'Status is not valid' }, 400);
+  }
+
+  return next();
+};
+
+const isOperationValid = (orderStatus, newStatus) => {
+  if (
+    (orderStatus === 'pending' && newStatus !== 'on_transit') ||
+    (orderStatus === 'in_transit' && newStatus !== 'delivered')
+  )
+    return false;
+
+  return true;
+};
+
+export const validateStatusUpdate = (req, res, next) => {
+  const { id } = req.params;
+  const newStatus = req.body.status;
+
+  const getOrder = getOrderByAttribute({ id });
+  if (!getOrder) {
+    return formatResponse(res, { message: 'Order not found' }, 404);
+  }
+
+  const { status } = getOrder[0];
+
+  if (status === 'cancelled') {
+    return formatResponse(
+      res,
+      { message: 'Cannot update a cancelled order' },
+      400,
+    );
+  }
+
+  if (!isOperationValid(status, newStatus)) {
+    return formatResponse(
+      res,
+      { message: `The status of this order cannot be updated to ${newStatus}` },
+      400,
+    );
+  }
+
+  req.id = getOrder[0].id;
+  req.status = newStatus;
+
+  return next();
+};

--- a/src/middlewares/validateOrder.js
+++ b/src/middlewares/validateOrder.js
@@ -36,10 +36,10 @@ export const checkStatus = (req, res, next) => {
   const { status } = req.body;
 
   if (STATUSES.includes(status)) {
-    return formatResponse(res, { error: 'Status is not valid' }, 400);
+    return next();
   }
 
-  return next();
+  return formatResponse(res, { error: 'Status is not valid' }, 400);
 };
 
 const isOperationValid = (orderStatus, newStatus) => {
@@ -52,15 +52,14 @@ const isOperationValid = (orderStatus, newStatus) => {
   return true;
 };
 
-export const validateStatusUpdate = (req, res, next) => {
+export const validateStatusUpdate = async (req, res, next) => {
   const { id } = req.params;
   const newStatus = req.body.status;
 
-  const getOrder = getOrderByAttribute({ id });
-  if (!getOrder) {
+  const getOrder = await getOrderByAttribute({ id });
+  if (!getOrder.length) {
     return formatResponse(res, { message: 'Order not found' }, 404);
   }
-
   const { status } = getOrder[0];
 
   if (status === 'cancelled') {
@@ -74,7 +73,9 @@ export const validateStatusUpdate = (req, res, next) => {
   if (!isOperationValid(status, newStatus)) {
     return formatResponse(
       res,
-      { message: `The status of this order cannot be updated to ${newStatus}` },
+      {
+        message: `The status of this order cannot be updated to ${newStatus}`,
+      },
       400,
     );
   }

--- a/src/middlewares/validateProduct.js
+++ b/src/middlewares/validateProduct.js
@@ -1,6 +1,7 @@
 import { body, check } from 'express-validator';
 import { getProductByAttribute } from '../resources/product/models/index.models';
-import { formatResponse, handleErrors } from '../helpers/baseHelper';
+import { formatResponse } from '../helpers/baseHelper';
+import handleErrors from './baseMiddleware';
 
 export const validateProduct = [
   check('name')

--- a/src/middlewares/validateUser.js
+++ b/src/middlewares/validateUser.js
@@ -1,5 +1,5 @@
 import { check, body } from 'express-validator';
-import { handleErrors } from '../helpers/baseHelper';
+import handleErrors from './baseMiddleware';
 
 export const validateUser = [
   check('firstname')

--- a/src/middlewares/validateUserAddress.js
+++ b/src/middlewares/validateUserAddress.js
@@ -1,5 +1,5 @@
 import { check } from 'express-validator';
-import { handleErrors } from '../helpers/baseHelper';
+import handleErrors from './baseMiddleware';
 
 const validateUserAddress = [
   check('user_id')

--- a/src/resources/order/models/index.model.js
+++ b/src/resources/order/models/index.model.js
@@ -1,6 +1,6 @@
 import Order from './order.model';
 
-async function createOrder(order, products) {
+export async function createOrder(order, products) {
   // eslint-disable-next-line no-return-await
   return await Order.transaction(async (trx) => {
     const transformedProducts = products.map((prod) => {
@@ -20,4 +20,12 @@ async function createOrder(order, products) {
   });
 }
 
-export default createOrder;
+export async function updateStatus(orderId, status) {
+  return Order.query().patch({ status }).where({ id: orderId }).returning('*');
+}
+
+export async function getOrderByAttribute(attribute) {
+  return Order.query()
+    .where({ ...attribute })
+    .returning('*');
+}

--- a/src/resources/order/models/order.model.js
+++ b/src/resources/order/models/order.model.js
@@ -43,3 +43,5 @@ export default class Order extends Model {
     };
   }
 }
+
+export const STATUSES = ['pending', 'in_transit', 'delivered', 'cancelled'];

--- a/src/resources/order/order.route.js
+++ b/src/resources/order/order.route.js
@@ -1,11 +1,23 @@
 import { Router } from 'express';
 
-import { verifyAuth } from '../../middlewares/validateUserAuth';
-import addOrder from './orders.controller';
-import validateOrder from '../../middlewares/validateOrder';
+import { verifyAuth, validateAdmin } from '../../middlewares/validateUserAuth';
+import { addOrder, updateOrder } from './orders.controller';
+import {
+  validateOrder,
+  validateStatusUpdate,
+  checkStatus,
+} from '../../middlewares/validateOrder';
 
 const router = Router();
 
 router.post('/orders', verifyAuth, validateOrder, addOrder);
+router.patch(
+  '/orders/:id',
+  verifyAuth,
+  validateAdmin,
+  checkStatus,
+  validateStatusUpdate,
+  updateOrder,
+);
 
 export default router;

--- a/src/resources/order/orders.controller.js
+++ b/src/resources/order/orders.controller.js
@@ -31,7 +31,7 @@ export const addOrder = async (req, res) => {
 };
 
 export const updateOrder = async (req, res) => {
-  const { id, status } = req.body;
+  const { id, status } = req;
   try {
     const response = await updateStatus(id, status);
     return formatResponse(
@@ -40,7 +40,7 @@ export const updateOrder = async (req, res) => {
       200,
       { order: response[0] },
     );
-  } catch (e) {
+  } catch (error) {
     return formatResponse(
       res,
       { error: 'Cannot update order at the moment, try again later' },

--- a/src/resources/order/orders.controller.js
+++ b/src/resources/order/orders.controller.js
@@ -1,8 +1,8 @@
 /* eslint-disable camelcase */
-import createOrder from './models/index.model';
+import { createOrder, updateStatus } from './models/index.model';
 import { formatResponse } from '../../helpers/baseHelper';
 
-const addOrder = async (req, res) => {
+export const addOrder = async (req, res) => {
   const { id } = req.user;
   const { shipping_address, shipping_fee, total_price, products } = req.body;
 
@@ -30,4 +30,21 @@ const addOrder = async (req, res) => {
   }
 };
 
-export default addOrder;
+export const updateOrder = async (req, res) => {
+  const { id, status } = req.body;
+  try {
+    const response = await updateStatus(id, status);
+    return formatResponse(
+      res,
+      { message: 'Order status successfully updated' },
+      200,
+      { order: response[0] },
+    );
+  } catch (e) {
+    return formatResponse(
+      res,
+      { error: 'Cannot update order at the moment, try again later' },
+      500,
+    );
+  }
+};

--- a/src/resources/order/spec/order.spec.js
+++ b/src/resources/order/spec/order.spec.js
@@ -1,8 +1,11 @@
 import request from 'supertest';
 import app from '../../../server';
 import db from '../../../db/dbconfig';
+import { hashPassword } from '../../../helpers/baseHelper';
 
 let userToken;
+let adminToken;
+let newOrder;
 
 const user = {
   firstname: 'kells',
@@ -24,9 +27,18 @@ const fakeProducts = [
   { id: 14, quantity: 45 },
 ];
 
+const pass = hashPassword(user.password);
 beforeAll(async () => {
-  await db.raw('truncate users cascade');
+  await db.raw('DELETE FROM users');
   await db.raw('truncate orders cascade');
+  await db.raw(
+    `INSERT INTO users (firstname, lastname, email, password, role) VALUES('kells1', 'leo1', 'order@gmail1.com', '${pass}', 'admin')`,
+  );
+  const loginResponse = await request(app)
+    .post('/api/v1/auth/login')
+    .set('content-type', 'application/json')
+    .send({ email: 'order@gmail1.com', password: user.password });
+  adminToken = loginResponse.body.token;
 
   user.email = 'kelly4eva@gmail.com';
   const userResponse = await request(app)
@@ -72,6 +84,8 @@ describe('POST Order', () => {
         .post('/api/v1/orders')
         .set({ 'x-auth-token': userToken, Accept: 'application/json' })
         .send({ ...order, products });
+
+      newOrder = response.body.order;
       expect(response.statusCode).toBe(201);
       expect(response.body.message).toEqual('Order created successfully');
     });
@@ -153,5 +167,99 @@ describe('POST Order', () => {
     expect(response.body.error).toEqual(
       expect.arrayContaining(['Total price must be a float number']),
     );
+  });
+});
+
+describe('PATCH order', () => {
+  it('should fail if user is not authenticated', async () => {
+    const response = await request(app)
+      .patch(`/api/v1/orders/${newOrder.id}`)
+      .set({ Accept: 'application/json' })
+      .send({ status: 'pending' });
+    expect(response.statusCode).toBe(401);
+    expect(response.body.error).toEqual(
+      'Access denied. You are not authorized to access this route',
+    );
+  });
+
+  it('should fail if user is not an admin', async () => {
+    const response = await request(app)
+      .patch(`/api/v1/orders/${newOrder.id}`)
+      .set({ 'x-auth-token': userToken, Accept: 'application/json' })
+      .send({ status: 'pending' });
+    expect(response.statusCode).toBe(403);
+    expect(response.body.error).toEqual(
+      'You are not authorized to perform this action',
+    );
+  });
+
+  it('should fail if status provided is not valid', async () => {
+    const response = await request(app)
+      .patch(`/api/v1/orders/${newOrder.id}`)
+      .set({ 'x-auth-token': adminToken, Accept: 'application/json' })
+      .send({ status: 'transit' });
+    expect(response.statusCode).toBe(400);
+    expect(response.body.error).toEqual('Status is not valid');
+  });
+
+  it('should fail if order does not exist', async () => {
+    const response = await request(app)
+      .patch('/api/v1/orders/90000')
+      .set({ 'x-auth-token': adminToken, Accept: 'application/json' })
+      .send({ status: 'in_transit' });
+    expect(response.statusCode).toBe(404);
+    expect(response.body.message).toEqual('Order not found');
+  });
+
+  it('should fail if updated status is not "in_transit"', async () => {
+    const response = await request(app)
+      .patch(`/api/v1/orders/${newOrder.id}`)
+      .set({ 'x-auth-token': adminToken, Accept: 'application/json' })
+      .send({ status: 'delivered' });
+    expect(response.statusCode).toBe(400);
+    expect(response.body.message).toEqual(
+      'The status of this order cannot be updated to delivered',
+    );
+  });
+
+  it('should fail if updated status is not "delivered"', async () => {
+    const updateOrder = await db.raw(
+      `UPDATE orders SET status = 'in_transit' WHERE id='${newOrder.id}' returning *`,
+    );
+
+    const updatedOrder = updateOrder.rows[0];
+    newOrder = updatedOrder;
+    const response = await request(app)
+      .patch(`/api/v1/orders/${newOrder.id}`)
+      .set({ 'x-auth-token': adminToken, Accept: 'application/json' })
+      .send({ status: 'in_transit' });
+    expect(response.statusCode).toBe(400);
+    expect(response.body.message).toEqual(
+      'The status of this order cannot be updated to in_transit',
+    );
+  });
+
+  it('should update status', async () => {
+    const response = await request(app)
+      .patch(`/api/v1/orders/${newOrder.id}`)
+      .set({ 'x-auth-token': adminToken, Accept: 'application/json' })
+      .send({ status: 'delivered' });
+    expect(response.statusCode).toBe(200);
+    expect(response.body.order.status).toEqual('delivered');
+    expect(response.body.message).toEqual('Order status successfully updated');
+  });
+
+  it('should fail if order is canceled', async () => {
+    const updateOrder = await db.raw(
+      `UPDATE orders SET status = 'cancelled' WHERE id='${newOrder.id}' returning id`,
+    );
+
+    const { id } = updateOrder.rows[0];
+    const response = await request(app)
+      .patch(`/api/v1/orders/${id}`)
+      .set({ 'x-auth-token': adminToken, Accept: 'application/json' })
+      .send({ status: 'in_transit' });
+    expect(response.statusCode).toBe(400);
+    expect(response.body.message).toEqual('Cannot update a cancelled order');
   });
 });


### PR DESCRIPTION
#### What does this PR do?
- It gives an admin the ability to update order status
......

#### How can it be manually tested?
- Login as an admin
- Visit `PATCH api/v1/orders/:id` and supply the new status as part of the request body
......

#### Are there test specs for this?
- Yes
......

#### Link to the ticket on `Notion`
[update status](https://www.notion.so/5a87fb8fa8e1476ab938ae315d474e6e?v=157e0b179b404a3cadd1e943f0d2be95&p=43f161bae0be4af58da1cc29f6b1e5b1)
......

#### Any background contest?
- N/A
......
