### PR TITLE
Cancel order

### DIFF
--- a/src/db/migrations/20200402151731_orders.js
+++ b/src/db/migrations/20200402151731_orders.js
@@ -1,19 +1,24 @@
+import { updateTrigger, onUpdateTrigger } from '../../../knexfile';
+
 export function up(knex) {
-  return knex.schema.createTable('orders', (table) => {
-    table.increments('id');
-    table
-      .integer('user_id')
-      .references('id')
-      .inTable('users')
-      .onUpdate('CASCADE')
-      .onDelete('CASCADE');
-    table.enu('status', ['pending', 'in_transit', 'delivered', 'cancelled']);
-    table.float('shipping_fee');
-    table.text('shipping_address').notNullable();
-    table.timestamp('shipped_time').nullable();
-    table.timestamp('created_at').defaultTo(knex.fn.now());
-    table.timestamp('updated_at').nullable();
-  });
+  return knex.schema
+    .createTable('orders', (table) => {
+      table.increments('id');
+      table
+        .integer('user_id')
+        .references('id')
+        .inTable('users')
+        .onUpdate('CASCADE')
+        .onDelete('CASCADE');
+      table.enu('status', ['pending', 'in_transit', 'delivered', 'cancelled']);
+      table.float('shipping_fee');
+      table.text('shipping_address').notNullable();
+      table.timestamp('shipped_time').nullable();
+      table.timestamp('created_at').defaultTo(knex.fn.now());
+      table.timestamp('updated_at').nullable();
+    })
+    .raw(updateTrigger())
+    .raw(onUpdateTrigger('orders'));
 }
 
 export function down(knex) {

--- a/src/db/migrations/20200729222633_add_delivery_time_to_orders.js
+++ b/src/db/migrations/20200729222633_add_delivery_time_to_orders.js
@@ -1,0 +1,11 @@
+export function up(knex) {
+  return knex.schema.table('orders', (table) => {
+    table.timestamp('delivered_at').nullable();
+  });
+}
+
+export function down(knex) {
+  return knex.schema.table('orders', (table) => {
+    table.dropColumn('delivered_at');
+  });
+}

--- a/src/middlewares/baseMiddleware.js
+++ b/src/middlewares/baseMiddleware.js
@@ -10,4 +10,8 @@ const handleErrors = (req, res, next) => {
   return next();
 };
 
+export const isAdmin = (user) => user.role.toLowerCase() === 'admin';
+
+export const userIsOwner = (user, ownerId) => user.id === ownerId;
+
 export default handleErrors;

--- a/src/middlewares/validateOrder.js
+++ b/src/middlewares/validateOrder.js
@@ -45,7 +45,7 @@ export const checkStatus = (req, res, next) => {
 
 const isOperationValid = (orderStatus, newStatus) => {
   if (
-    (orderStatus === 'pending' && newStatus !== 'on_transit') ||
+    (orderStatus === 'pending' && newStatus !== 'in_transit') ||
     (orderStatus === 'in_transit' && newStatus !== 'delivered')
   )
     return false;
@@ -90,10 +90,10 @@ export const validateStatusUpdate = async (req, res, next) => {
 
   const { status } = order;
 
-  if (status === 'cancelled') {
+  if (status === 'cancelled' || status === 'delivered') {
     return formatResponse(
       res,
-      { message: 'Cannot update a cancelled order' },
+      { message: `Cannot update a ${status} order` },
       400,
     );
   }

--- a/src/resources/order/models/index.model.js
+++ b/src/resources/order/models/index.model.js
@@ -25,6 +25,10 @@ export async function updateStatus(orderId, status) {
   return Order.query().patch({ status }).where({ id: orderId }).returning('*');
 }
 
+export async function updateShippedOrDeliveredTime(orderId, column) {
+  return db.raw(`UPDATE orders SET ${column} = NOW() WHERE id = ?`, [orderId]);
+}
+
 export async function getOrderByAttribute(attribute) {
   return Order.query()
     .where({ ...attribute })

--- a/src/resources/order/order.route.js
+++ b/src/resources/order/order.route.js
@@ -1,13 +1,20 @@
 import { Router } from 'express';
 
 import { verifyAuth, validateAdmin } from '../../middlewares/validateUserAuth';
-import { addOrder, updateOrder, getOrderById } from './orders.controller';
+import {
+  addOrder,
+  updateOrder,
+  getOrderById,
+  cancelOrder,
+} from './orders.controller';
 import {
   validateOrder,
   validateStatusUpdate,
   checkStatus,
   checkIfOrderExists,
   restrictAccessToOwnerAndAdmin,
+  checkIfUserIsOwner,
+  allowOnlyPendingOrder,
 } from '../../middlewares/validateOrder';
 
 const router = Router();
@@ -30,6 +37,15 @@ router.get(
   checkIfOrderExists,
   restrictAccessToOwnerAndAdmin,
   getOrderById,
+);
+
+router.patch(
+  '/orders/:id/cancel',
+  verifyAuth,
+  checkIfOrderExists,
+  checkIfUserIsOwner,
+  allowOnlyPendingOrder,
+  cancelOrder,
 );
 
 export default router;

--- a/src/resources/order/orders.controller.js
+++ b/src/resources/order/orders.controller.js
@@ -87,3 +87,24 @@ export const getOrderById = async (req, res) => {
     );
   }
 };
+
+export const cancelOrder = async (req, res) => {
+  const {
+    order: { id },
+  } = req;
+  try {
+    const response = await updateStatus(id, 'cancelled');
+    return formatResponse(
+      res,
+      { message: 'Order status successfully cancelled' },
+      200,
+      { order: response[0] },
+    );
+  } catch (error) {
+    return formatResponse(
+      res,
+      { error: 'Cannot cancel order at the moment, try again later' },
+      500,
+    );
+  }
+};

--- a/src/resources/order/orders.controller.js
+++ b/src/resources/order/orders.controller.js
@@ -5,6 +5,7 @@ import {
   getOrderWithProducts,
   formatOrderFromResponse,
   getProducts,
+  updateShippedOrDeliveredTime,
 } from './models/index.model';
 import { formatResponse } from '../../helpers/baseHelper';
 
@@ -38,7 +39,15 @@ export const addOrder = async (req, res) => {
 
 export const updateOrder = async (req, res) => {
   const { id, status } = req;
+  const columns = {
+    in_transit: 'shipped_time',
+    delivered: 'delivered_at',
+  };
+
   try {
+    if (status === 'in_transit' || status === 'delivered') {
+      await updateShippedOrDeliveredTime(id, columns[status]);
+    }
     const response = await updateStatus(id, status);
     return formatResponse(
       res,

--- a/src/resources/order/spec/order.spec.js
+++ b/src/resources/order/spec/order.spec.js
@@ -278,6 +278,20 @@ describe('PATCH order', () => {
     expect(response.statusCode).toBe(400);
     expect(response.body.message).toEqual('Cannot update a cancelled order');
   });
+
+  it('should fail if order is delivered', async () => {
+    const updateOrder = await db.raw(
+      `UPDATE orders SET status = 'delivered' WHERE id='${newOrder.id}' returning id`,
+    );
+
+    const { id } = updateOrder.rows[0];
+    const response = await request(app)
+      .patch(`/api/v1/orders/${id}`)
+      .set({ 'x-auth-token': adminToken, Accept: 'application/json' })
+      .send({ status: 'in_transit' });
+    expect(response.statusCode).toBe(400);
+    expect(response.body.message).toEqual('Cannot update a delivered order');
+  });
 });
 
 describe('GET orders', () => {

--- a/src/resources/order/spec/order.spec.js
+++ b/src/resources/order/spec/order.spec.js
@@ -388,7 +388,9 @@ describe('CANCEL order', () => {
     const response = await request(app)
       .patch(`/api/v1/orders/${id}/cancel`)
       .set({ 'x-auth-token': userToken, Accept: 'application/json' });
+
     expect(response.statusCode).toBe(200);
+    expect(response.body.order.status).toBe('cancelled');
     expect(response.body.message).toEqual(
       'Order status successfully cancelled',
     );


### PR DESCRIPTION
#### What does this PR do?
- It adds `delivered_at` column to the orders table
- It cancels an order that hasn't been shipped yet

#### How can it be manually tested?
- Run migrations
- Login and create an order if you don't already have one.
- Visiting `api/v1/orders/:id/1/cancel` should cancel the order

#### Are there test specs for this?
- Yes

#### Link to the ticket on `Notion`
- [Cancel order](https://www.notion.so/5a87fb8fa8e1476ab938ae315d474e6e?v=157e0b179b404a3cadd1e943f0d2be95&p=fe05f60728594cef8fce3c0b22cda8b1)

#### Any background contest?
- N/A
